### PR TITLE
Fix UIBarButtonItem onTap animation

### DIFF
--- a/Source/SwiftIcons.swift
+++ b/Source/SwiftIcons.swift
@@ -676,7 +676,7 @@ public extension UIBarButtonItem {
         
         title = nil
         let button = UIButton(frame: cgRect)
-        let onTapColor = color.withAlphaComponent(0.4)
+        let onTapColor = iconColor.withAlphaComponent(0.4)
         button.setIcon(prefixText: prefixText, prefixTextFont: prefixTextFont, prefixTextColor: prefixTextColor, icon: icon, iconColor: iconColor, postfixText: postfixText, postfixTextFont: postfixTextFont, postfixTextColor: postfixTextColor, backgroundColor: .clear, forState: .normal, iconSize: iconSize)
         button.addTarget(target, action: action, for: .touchUpInside)
         button.setTitleColor(onTapColor, for: .highlighted)

--- a/Source/SwiftIcons.swift
+++ b/Source/SwiftIcons.swift
@@ -614,8 +614,10 @@ public extension UIBarButtonItem {
         
         title = nil
         let button = UIButton(frame: cgRect)
+        let onTapColor = color.withAlphaComponent(0.4)
         button.setIcon(icon: icon, iconSize: iconSize, color: color, forState: .normal)
         button.addTarget(target, action: action, for: .touchUpInside)
+        button.setTitleColor(onTapColor, for: .highlighted)
         
         customView = button
     }
@@ -642,8 +644,10 @@ public extension UIBarButtonItem {
         
         title = nil
         let button = UIButton(frame: cgRect)
+        let onTapColor = color.withAlphaComponent(0.4)
         button.setIcon(prefixText: prefixText, prefixTextColor: prefixTextColor, icon: icon!, iconColor: iconColor, postfixText: postfixText, postfixTextColor: postfixTextColor, backgroundColor: .clear, forState: .normal, textSize: size, iconSize: iconSize)
         button.addTarget(target, action: action, for: .touchUpInside)
+        button.setTitleColor(onTapColor, for: .highlighted)
         
         customView = button
     }
@@ -672,8 +676,10 @@ public extension UIBarButtonItem {
         
         title = nil
         let button = UIButton(frame: cgRect)
+        let onTapColor = color.withAlphaComponent(0.4)
         button.setIcon(prefixText: prefixText, prefixTextFont: prefixTextFont, prefixTextColor: prefixTextColor, icon: icon, iconColor: iconColor, postfixText: postfixText, postfixTextFont: postfixTextFont, postfixTextColor: postfixTextColor, backgroundColor: .clear, forState: .normal, iconSize: iconSize)
         button.addTarget(target, action: action, for: .touchUpInside)
+        button.setTitleColor(onTapColor, for: .highlighted)
         
         customView = button
     }

--- a/Source/SwiftIcons.swift
+++ b/Source/SwiftIcons.swift
@@ -644,7 +644,7 @@ public extension UIBarButtonItem {
         
         title = nil
         let button = UIButton(frame: cgRect)
-        let onTapColor = color.withAlphaComponent(0.4)
+        let onTapColor = iconColor.withAlphaComponent(0.4)
         button.setIcon(prefixText: prefixText, prefixTextColor: prefixTextColor, icon: icon!, iconColor: iconColor, postfixText: postfixText, postfixTextColor: postfixTextColor, backgroundColor: .clear, forState: .normal, textSize: size, iconSize: iconSize)
         button.addTarget(target, action: action, for: .touchUpInside)
         button.setTitleColor(onTapColor, for: .highlighted)


### PR DESCRIPTION
Since it is a custom button, fading effect on button tap is removed. This adds back onTap fading effect.