### PR TITLE
Ignore error if font was already registered

### DIFF
--- a/Source/SwiftIcons.swift
+++ b/Source/SwiftIcons.swift
@@ -43,7 +43,11 @@ public extension UIImage {
         let fontAspectRatio: CGFloat = 1.28571429
         let fontSize = min(size.width / fontAspectRatio, size.height)
         let font = UIFont(name: icon.fontName(), size: fontSize)
-        assert(font != nil, icon.errorAnnounce())
+		if font == nil {
+			self.init()
+			return
+		} // prevent unnecessary crash
+		
         let attributes = [NSAttributedString.Key.font: font!, NSAttributedString.Key.foregroundColor: textColor, NSAttributedString.Key.backgroundColor: backgroundColor, NSAttributedString.Key.paragraphStyle: paragraph]
         let lineHeight = font!.lineHeight
         let attributedString = NSAttributedString(string: icon.text!, attributes: attributes)

--- a/Source/SwiftIcons.swift
+++ b/Source/SwiftIcons.swift
@@ -730,13 +730,15 @@ private class FontLoader {
             let font = CGFont(provider!)!
 
             var error: Unmanaged<CFError>?
-            if !CTFontManagerRegisterGraphicsFont(font, &error) {
-                let errorDescription: CFString = CFErrorCopyDescription(error!.takeUnretainedValue())
-                let nsError = error!.takeUnretainedValue() as AnyObject as! NSError
-                NSException(name: NSExceptionName.internalInconsistencyException, reason: errorDescription as String, userInfo: [NSUnderlyingErrorKey: nsError]).raise()
-            } else {
-                loadedFontsTracker[fontName] = true
-            }
+			if !CTFontManagerRegisterGraphicsFont(font, &error) {
+				let errorDescription: CFString = CFErrorCopyDescription(error!.takeUnretainedValue())
+				let nsError = error!.takeUnretainedValue() as AnyObject as! NSError
+				if nsError.code != 105 {
+					NSException(name: NSExceptionName.internalInconsistencyException, reason: errorDescription as String, userInfo: [NSUnderlyingErrorKey: nsError]).raise()
+				}
+			}
+			
+			loadedFontsTracker[fontName] = true
         }
     }
 }


### PR DESCRIPTION
This won't throw error if user already had a same font installed in their project for other purpose.